### PR TITLE
Fix error on unmounted state.

### DIFF
--- a/styled_text/lib/styled_text.dart
+++ b/styled_text/lib/styled_text.dart
@@ -373,10 +373,10 @@ class _StyledTextState extends State<StyledText> {
         }
       }).onDone(() {
         _rootNode = node;
+        if (mounted) {
         final span = node.createSpan(context: context);
         _textSpans = TextSpan(style: defaultStyle, children: [span]);
 
-        if (mounted) {
           setState(() {});
         }
       });


### PR DESCRIPTION
I was getting this error:

```
I/flutter (15201): ### Zone error: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
I/flutter (15201): Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
I/flutter (15201): ### #0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:909:9)
I/flutter (15201): #1      State.context (package:flutter/src/widgets/framework.dart:915:6)
I/flutter (15201): #2      _StyledTextState._updateTextSpans.<anonymous closure> (package:styled_text/styled_text.dart:376:47)
```

I've extended the guarded block to ensure `context` isn't accessed if unmounted.